### PR TITLE
Fix for @Entity without name.

### DIFF
--- a/src/main/java/org/torpedoquery/jpa/internal/query/DefaultQueryBuilder.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/query/DefaultQueryBuilder.java
@@ -94,7 +94,7 @@ public class DefaultQueryBuilder<T> implements QueryBuilder<T> {
 	private String getEntityName() {
 		
 		Entity e = toQuery.getAnnotation(Entity.class);
-		if (e!=null&&e.name()!=null)
+		if (e!=null && e.name()!=null && !e.name().trim().isEmpty() )
 			return e.name();
 		else
 		return toQuery.getSimpleName();

--- a/src/test/java/org/torpedoquery/jpa/EntityNameTest.java
+++ b/src/test/java/org/torpedoquery/jpa/EntityNameTest.java
@@ -56,11 +56,29 @@ public class EntityNameTest {
 		}
 	}
 
+	@javax.persistence.Entity()
+	public static class EntityWithAnnotationWithoutName {
+		@Id
+		private String id = UUID.randomUUID().toString();
+
+		public String getId() {
+			return id;
+		}
+	}
+
 	@Test
-	public void test_createQuery() {
+	public void test_createQueryWithName() {
 		final EntityWithAnnotationName entity = from(EntityWithAnnotationName.class);
 		org.torpedoquery.jpa.Query<EntityWithAnnotationName> select = select(entity);
 		assertEquals("select myEntity_0 from myEntity myEntity_0",
+				select.getQuery());
+	}
+	
+	@Test
+	public void test_createQueryWithoutName() {
+		final EntityWithAnnotationWithoutName entity = from(EntityWithAnnotationWithoutName.class);
+		org.torpedoquery.jpa.Query<EntityWithAnnotationWithoutName> select = select(entity);
+		assertEquals("select entityWithAnnotationWithoutName_0 from EntityWithAnnotationWithoutName entityWithAnnotationWithoutName_0",
 				select.getQuery());
 	}
 }


### PR DESCRIPTION
Turns out @Entity.name() defaults to "" instead of null, fixed the
comparison.
