### PR TITLE
construct(Class, Object, Object...) for Projection and fix on InCondition (loose brackets)

### DIFF
--- a/src/main/java/org/torpedoquery/jpa/Torpedo.java
+++ b/src/main/java/org/torpedoquery/jpa/Torpedo.java
@@ -15,18 +15,21 @@
  */
 package org.torpedoquery.jpa;
 
-import static org.torpedoquery.jpa.internal.TorpedoMagic.getTorpedoMethodHandler;
-import static org.torpedoquery.jpa.internal.TorpedoMagic.setQuery;
+import static org.torpedoquery.jpa.internal.TorpedoMagic.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.torpedoquery.core.QueryBuilder;
-import org.torpedoquery.jpa.internal.TorpedoProxy;
+import org.torpedoquery.jpa.internal.Parameter;
 import org.torpedoquery.jpa.internal.Selector;
-import org.torpedoquery.jpa.internal.conditions.LogicalCondition;
+import org.torpedoquery.jpa.internal.TorpedoProxy;
 import org.torpedoquery.jpa.internal.handlers.ArrayCallHandler;
 import org.torpedoquery.jpa.internal.handlers.GroupingConditionHandler;
 import org.torpedoquery.jpa.internal.handlers.InnerJoinHandler;
@@ -36,6 +39,7 @@ import org.torpedoquery.jpa.internal.handlers.ValueHandler;
 import org.torpedoquery.jpa.internal.handlers.WhereClauseHandler;
 import org.torpedoquery.jpa.internal.query.DefaultQueryBuilder;
 import org.torpedoquery.jpa.internal.query.GroupBy;
+import org.torpedoquery.jpa.internal.query.SelectorParameter;
 import org.torpedoquery.jpa.internal.utils.DoNothingQueryConfigurator;
 import org.torpedoquery.jpa.internal.utils.MultiClassLoaderProvider;
 import org.torpedoquery.jpa.internal.utils.ProxyFactoryFactory;
@@ -44,6 +48,7 @@ import org.torpedoquery.jpa.internal.utils.WhereQueryConfigurator;
 import org.torpedoquery.jpa.internal.utils.WithQueryConfigurator;
 
 import com.google.common.base.Throwables;
+
 
 /**
  * Torpedo Query goal is to simplify how you create and maintain your HQL query.
@@ -706,4 +711,86 @@ public class Torpedo extends TorpedoFunction {
 
 	}
 
+	
+
+    private static <X> ConstructFunction<X> getConstructFunction(Class<X> x, Object firstValue,
+            Object... additionalValues) {
+        Objects.requireNonNull(x);
+        Objects.requireNonNull(firstValue);
+
+        List<Object> l = new ArrayList<Object>();
+        l.add(firstValue);
+
+        if (additionalValues != null && additionalValues.length > 0) {
+            l.addAll(Arrays.asList(additionalValues));
+        }
+
+        final ConstructFunction<X> f = new ConstructFunction<X>(x);
+        getTorpedoMethodHandler().handle(new ArrayCallHandler(new ValueHandler<Void>() {
+            @SuppressWarnings("rawtypes")
+            @Override
+            public Void handle(TorpedoProxy proxy, QueryBuilder queryBuilder, Selector selector) {
+                f.setQuery(proxy);
+                f.addSelector(selector);
+                return null;
+            }
+        }, l.toArray()));
+        return f;
+    }
+
+    public static <X> Function<X> construct(Class<X> valueClass, Object first,
+            Object... optionalAdditionalValues) {
+        Objects.requireNonNull(valueClass);
+        Objects.requireNonNull(first);
+        return getConstructFunction(valueClass, first, optionalAdditionalValues);
+    }
+
+    static class ConstructFunction<T> implements ComparableFunction<T> {
+
+        private final List<Selector<?>> selectors = new ArrayList<Selector<?>>();
+
+        private TorpedoProxy proxy;
+
+        private Class<T> x;
+
+        public ConstructFunction(Class<T> x) {
+            this.x = x;
+        }
+
+        @Override
+        public String createQueryFragment(AtomicInteger incrementor) {
+            StringBuffer stringBuffer = new StringBuffer();
+            Iterator<Selector<?>> iterator = selectors.iterator();
+            Selector<?> first = iterator.next();
+            stringBuffer.append("new " + x.getName() + "(").append(
+                    first.createQueryFragment(incrementor));
+
+            while (iterator.hasNext()) {
+                Selector<?> selector = iterator.next();
+                stringBuffer.append(", ").append(selector.createQueryFragment(incrementor));
+            }
+
+            stringBuffer.append(")");
+
+            return stringBuffer.toString();
+        }
+
+        @Override
+        public Object getProxy() {
+            return proxy;
+        }
+
+        public void addSelector(Selector<?> selector) {
+            selectors.add(selector);
+        }
+
+        public void setQuery(TorpedoProxy proxy) {
+            this.proxy = proxy;
+        }
+
+        @Override
+        public Parameter<T> generateParameter(T value) {
+            return new SelectorParameter<T>(this);
+        }
+    }
 }

--- a/src/main/java/org/torpedoquery/jpa/internal/conditions/InCondition.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/conditions/InCondition.java
@@ -35,7 +35,8 @@ public class InCondition<T> extends AbstractCondition<List<T>> {
 
 	@Override
 	public String createQueryFragment(AtomicInteger incrementor) {
-		return selector.createQueryFragment(incrementor) + " " + getFragment() + " ( " + parameter.generate(incrementor) + " ) ";
+	    // dont add brackets around IN parameter as it breaks current eclipselink (2.5.0 - 2.5.2) impls.
+		return selector.createQueryFragment(incrementor) + " " + getFragment() + " " + parameter.generate(incrementor);
 	}
 
 	protected String getFragment() {

--- a/src/test/java/org/torpedoquery/jpa/WhereClauseTest.java
+++ b/src/test/java/org/torpedoquery/jpa/WhereClauseTest.java
@@ -147,7 +147,7 @@ public class WhereClauseTest {
 		Query<Entity> select = select(from);
 
 		assertEquals(
-				"select entity_0 from Entity entity_0 where entity_0.primitiveInt in ( :primitiveInt_1 )",
+				"select entity_0 from Entity entity_0 where entity_0.primitiveInt in :primitiveInt_1",
 				select.getQuery());
 
 	}
@@ -173,7 +173,7 @@ public class WhereClauseTest {
 		Query<Entity> select = select(from);
 
 		assertEquals(
-				"select entity_0 from Entity entity_0 where entity_0.primitiveInt not in ( :primitiveInt_1 )",
+				"select entity_0 from Entity entity_0 where entity_0.primitiveInt not in :primitiveInt_1",
 				select.getQuery());
 
 	}


### PR DESCRIPTION
the construct method enables us to use something like

```java
X x = Torpedo.from(X.class);
ValueClass v = Torpedo.select(project(x.getId(), x.getDisplayName())).list(entityManager());
```
where ValueClass has a constructor of 
```java
public class ValueClass {
 ValueClass(IdType id, DisplayNameType displayName){ ... }
 //...
```

Also, there is a fix for IN that looses the brakcets around the IN parameter in case of .in(Collection), as it would break eclipselink. Don't know about hibernate, but as eclipselink is the standard impl, i guess they are right :)