### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/torpedoquery/jpa/internal/TorpedoMagic.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/TorpedoMagic.java
@@ -20,11 +20,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.torpedoquery.core.QueryBuilderFactory;
 import org.torpedoquery.jpa.internal.utils.TorpedoMethodHandler;
-public class TorpedoMagic {
+public final class TorpedoMagic {
 
 	private static final ThreadLocal<TorpedoProxy> query = new ThreadLocal<>();
 	private static AtomicReference<QueryBuilderFactory> factory = new AtomicReference<>(
 			new DefaultQueryBuilderFactory());
+
+	private TorpedoMagic() {
+	}
 
 	/**
 	 * <p>Setter for the field <code>query</code>.</p>

--- a/src/main/java/org/torpedoquery/jpa/internal/conditions/ConditionHelper.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/conditions/ConditionHelper.java
@@ -23,7 +23,11 @@ import org.torpedoquery.jpa.internal.TorpedoMagic;
 import org.torpedoquery.jpa.internal.handlers.WhereClauseHandler;
 import org.torpedoquery.jpa.internal.utils.DoNothingQueryConfigurator;
 import org.torpedoquery.jpa.internal.utils.TorpedoMethodHandler;
-public class ConditionHelper {
+public final class ConditionHelper {
+
+	private ConditionHelper() {
+	}
+
 	/**
 	 * <p>createCondition.</p>
 	 *

--- a/src/main/java/org/torpedoquery/jpa/internal/utils/FieldUtils.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/utils/FieldUtils.java
@@ -18,7 +18,11 @@ package org.torpedoquery.jpa.internal.utils;
 
 import java.beans.Introspector;
 import java.lang.reflect.Method;
-public class FieldUtils {
+public final class FieldUtils {
+
+	private FieldUtils() {
+	}
+
 	/**
 	 * <p>getFieldName.</p>
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat