### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and Strin…

### DIFF
--- a/src/main/java/org/torpedoquery/jpa/internal/functions/CoalesceFunction.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/functions/CoalesceFunction.java
@@ -35,19 +35,19 @@ public class CoalesceFunction<T> implements ComparableFunction<T> {
 	@Override
 	public String createQueryFragment(AtomicInteger incrementor) {
 
-		StringBuffer stringBuffer = new StringBuffer();
+		StringBuilder stringBuilder = new StringBuilder();
 		Iterator<Selector> iterator = selectors.iterator();
 		Selector first = iterator.next();
-		stringBuffer.append("coalesce(").append(first.createQueryFragment(incrementor));
+		stringBuilder.append("coalesce(").append(first.createQueryFragment(incrementor));
 
 		while (iterator.hasNext()) {
 			Selector selector = iterator.next();
-			stringBuffer.append(',').append(selector.createQueryFragment(incrementor));
+			stringBuilder.append(',').append(selector.createQueryFragment(incrementor));
 		}
 
-		stringBuffer.append(')');
+		stringBuilder.append(')');
 
-		return stringBuffer.toString();
+		return stringBuilder.toString();
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/torpedoquery/jpa/internal/functions/DynamicInstantiationFunction.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/functions/DynamicInstantiationFunction.java
@@ -45,19 +45,19 @@ public class DynamicInstantiationFunction<T> implements ComparableFunction<T> {
 	@Override
 	public String createQueryFragment(AtomicInteger incrementor) {
 
-		StringBuffer stringBuffer = new StringBuffer();
+		StringBuilder stringBuilder = new StringBuilder();
 		Iterator<Selector> iterator = selectors.iterator();
 		Selector first = iterator.next();
-		stringBuffer.append("new "+object.getClass().getName()+"(").append(first.createQueryFragment(incrementor));
+		stringBuilder.append("new "+object.getClass().getName()+"(").append(first.createQueryFragment(incrementor));
 
 		while (iterator.hasNext()) {
 			Selector selector = iterator.next();
-			stringBuffer.append(',').append(selector.createQueryFragment(incrementor));
+			stringBuilder.append(',').append(selector.createQueryFragment(incrementor));
 		}
 
-		stringBuffer.append(')');
+		stringBuilder.append(')');
 
-		return stringBuffer.toString();
+		return stringBuilder.toString();
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1149

Please let me know if you have any questions.

M-Ezzat