### PR TITLE
Multiple quality improvements - squid:S1488,  squid:S2325, squid:S1905

### DIFF
--- a/src/main/java/org/torpedoquery/jpa/TorpedoFunction.java
+++ b/src/main/java/org/torpedoquery/jpa/TorpedoFunction.java
@@ -186,8 +186,7 @@ public class TorpedoFunction {
 	 * @return a {@link org.torpedoquery.jpa.Function} object.
 	 */
 	public static <T> Function<T> coalesce(T... values) {
-		final CoalesceFunction<T> coalesceFunction = getCoalesceFunction(values);
-		return coalesceFunction;
+		return getCoalesceFunction(values);
 	}
 
 	private static <T> CoalesceFunction<T> getCoalesceFunction(T... values) {
@@ -235,8 +234,7 @@ public class TorpedoFunction {
 	 * @return a {@link org.torpedoquery.jpa.Function} object.
 	 */
 	public static <T> Function<T> dyn(T object) {
-		final DynamicInstantiationFunction<T> dynFunction = getDynamicInstantiationFunction(object);
-		return dynFunction;
+		return getDynamicInstantiationFunction(object);
 	}
 
 	/**

--- a/src/main/java/org/torpedoquery/jpa/internal/conditions/ConditionHelper.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/conditions/ConditionHelper.java
@@ -37,8 +37,7 @@ public final class ConditionHelper {
 	 * @return a E object.
 	 */
 	public static <T, E extends OnGoingCondition<T>> E createCondition(LogicalCondition condition) {
-		E handle = ConditionHelper.<T, E> createCondition(null, condition);
-		return handle;
+		return ConditionHelper.<T, E> createCondition(null, condition);
 	}
 
 	/**
@@ -53,8 +52,7 @@ public final class ConditionHelper {
 	public static <T, E extends OnGoingCondition<T>> E createCondition(Function<T> function, LogicalCondition condition) {
 		TorpedoMethodHandler fjpaMethodHandler = TorpedoMagic.getTorpedoMethodHandler();
 		WhereClauseHandler<T, E> whereClauseHandler = new WhereClauseHandler<>(function, condition, new DoNothingQueryConfigurator<>());
-		E handle = fjpaMethodHandler.handle(whereClauseHandler);
-		return handle;
+		return fjpaMethodHandler.handle(whereClauseHandler);
 	}
 	
 	

--- a/src/main/java/org/torpedoquery/jpa/internal/handlers/MathOperationHandler.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/handlers/MathOperationHandler.java
@@ -68,11 +68,10 @@ public class MathOperationHandler<T> implements QueryHandler<OnGoingMathOperatio
 		return createFunction(rightSelector, "+");
 	}
 
-	private SimpleMethodCallSelector handleMethodCall() {
+	private static SimpleMethodCallSelector handleMethodCall() {
 		TorpedoMethodHandler torpedoMethodHandler = TorpedoMagic.getTorpedoMethodHandler();
 		MethodCall methodCall = torpedoMethodHandler.getMethods().pollFirst();
-		SimpleMethodCallSelector rightSelector = new SimpleMethodCallSelector(torpedoMethodHandler.getQueryBuilder(methodCall.getProxy()), methodCall);
-		return rightSelector;
+		return new SimpleMethodCallSelector(torpedoMethodHandler.getQueryBuilder(methodCall.getProxy()), methodCall);
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/torpedoquery/jpa/internal/query/DefaultQueryBuilder.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/query/DefaultQueryBuilder.java
@@ -344,7 +344,7 @@ public class DefaultQueryBuilder<T> implements QueryBuilder<T> {
 		return valueParameters;
 	}
 
-	private void feedValueParameters(List<ValueParameter> valueParameters, Condition clauseCondition) {
+	private static void feedValueParameters(List<ValueParameter> valueParameters, Condition clauseCondition) {
 		if (clauseCondition != null) {
 			List<Parameter> parameters = clauseCondition.getParameters();
 			for (Parameter parameter : parameters) {

--- a/src/main/java/org/torpedoquery/jpa/internal/query/GroupBy.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/query/GroupBy.java
@@ -133,10 +133,10 @@ public class GroupBy implements OnGoingGroupByCondition {
 	@Override
 	public OnGoingLogicalCondition having(OnGoingLogicalCondition condition) {
 		LogicalCondition logicalCondition = (LogicalCondition)condition;
-		QueryBuilder builder = (QueryBuilder) logicalCondition.getBuilder();
+		QueryBuilder builder = logicalCondition.getBuilder();
 		LogicalCondition groupingLogicalCondition = new LogicalCondition(builder, new GroupingCondition(logicalCondition));
 		havingCondition = new ConditionBuilder(builder, groupingLogicalCondition, null);
-		return (OnGoingLogicalCondition) groupingLogicalCondition;
+		return groupingLogicalCondition;
 	}
 	
 	/**

--- a/src/main/java/org/torpedoquery/jpa/internal/utils/MultiClassLoaderProvider.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/utils/MultiClassLoaderProvider.java
@@ -39,7 +39,7 @@ public class MultiClassLoaderProvider implements ClassLoaderProvider {
 		public Class<?> loadClass(String name) throws ClassNotFoundException {
 
 			try {
-				return MultiClassLoaderProvider.class.getClassLoader().loadClass(name);
+				return Thread.currentThread().getContextClassLoader().loadClass(name);
 			} catch (ClassNotFoundException e1) {
 			}
 

--- a/src/main/java/org/torpedoquery/jpa/internal/utils/TorpedoMethodHandler.java
+++ b/src/main/java/org/torpedoquery/jpa/internal/utils/TorpedoMethodHandler.java
@@ -125,8 +125,7 @@ public class TorpedoMethodHandler implements MethodHandler, TorpedoProxy {
 	 * @return a T object.
 	 */
 	public <T> T handle(QueryHandler<T> handler) {
-		final T result = handler.handleCall(proxyQueryBuilders, methods);
-		return result;
+		return handler.handleCall(proxyQueryBuilders, methods);
 	}
 
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1488 - Local Variables should not be declared and then immediately returned or thrown
squid:S2325 - "private" methods that don't access instance data should be "static"
squid:S1905 - Redundant casts should not be used
pmd:UseProperClassLoader - Use Proper Class Loader

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1905
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UseProperClassLoader

Please let me know if you have any questions.

M-Ezzat